### PR TITLE
FixItemsShow

### DIFF
--- a/app/views/customer/items/show.html.erb
+++ b/app/views/customer/items/show.html.erb
@@ -13,7 +13,6 @@
       <h2>￥<%= @item.price %>円</h2>
       <%= form_with model: @cart_item, url: customer_cart_items_path, local:true do |f| %>
        <%= f.select :count, [["1", "1"], ["2", "2"], ["3", "3"], ["4", "4"], ["5", "5"]], include_blank: "個数選択　　　" %>
-       <%= f.hidden_field :customer_id, :value => current_customer.id %>
        <%= f.hidden_field :item_id, :value => @item.id %>
        <%= f.submit "カートに入れる", class: "btn btn-success" %>
       <% end %>


### PR DESCRIPTION
showページを非ログインでも見れるように。

修正箇所 showページのhidden_fieldにてカスタマーIDをcart_itemsを送るようにしていたため、非ログイン時だとカスタマーIDがないので閲覧できない状態になっていた。　hidden_fieldを削除　