### PR TITLE
Items layout

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,20 @@
 @import "bootstrap";
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
+
+/*ページネーション自体のデザイン*/
+.pagination>li>a {          
+  border: none;     /*枠線をなくす*/
+  color: #696969;   /*文字の色を変える*/
+}
+
+/* 表示しているページ番号のデザイン */
+.pagination>.active>a {     
+  background: #93c9ff;     /*背景の色を変える*/
+  border-radius: 15px;     /*角を丸くする*/
+}
+
+/*ホバー時のデザイン*/
+.pagination>li>a:hover {        
+  border-radius: 15px;    /*角を丸くする*/
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,19 +17,18 @@
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
 
-/*ページネーション自体のデザイン*/
+
 .pagination>li>a {          
-  border: none;     /*枠線をなくす*/
-  color: #696969;   /*文字の色を変える*/
+  border: none;     
+  color: #696969;   
 }
 
-/* 表示しているページ番号のデザイン */
+
 .pagination>.active>a {     
-  background: #93c9ff;     /*背景の色を変える*/
-  border-radius: 15px;     /*角を丸くする*/
+  background: #93c9ff;   
+  border-radius: 15px;   
 }
 
-/*ホバー時のデザイン*/
 .pagination>li>a:hover {        
-  border-radius: 15px;    /*角を丸くする*/
+  border-radius: 15px;   
 }

--- a/app/helpers/customer/items_helper.rb
+++ b/app/helpers/customer/items_helper.rb
@@ -1,2 +1,8 @@
 module Customer::ItemsHelper
+    
+    # 税込の計算
+    def tax_price(price)
+      (price*1.1).floor
+    end
+    
 end

--- a/app/views/customer/items/index.html.erb
+++ b/app/views/customer/items/index.html.erb
@@ -1,21 +1,20 @@
 <div class="container">
     <div class="row">
-        <div class="col-xs-1">
-        </div>
-        <div class="col-xs-9">
-            <h2>商品一覧</h2><span style="font-size-20px;">(全<%= @count %>件)</span>
-            <div class="row">
+        <div class="col-md-12 align-ceter">
+            <h2>商品一覧</h2><span>(全<%= @count %>件)</span>
+            <div class="row mt-4 align-center">
                 <% @items.each do |item| %>
-                <div class="box" style="float:left;">
-                    <%= link_to customer_item_path(item.id) do %><!-- 画像クリックで詳細ページへ -->
+                <div class="col-md-3">
+                    <div class="d-flex justify-content-center">
+                     <%= link_to customer_item_path(item.id) do %><!-- 画像クリックで詳細ページへ -->
                      <%= attachment_image_tag item, :image, size: "150x150", fallback: "no-image.jpg" %>
                      <% end %>
-                     <p><%= item.name %></p>
-                     <p><%= item.price %>円</p>
+                    </div>
+                     <p class="text-center"><%= item.name %><br><%= item.price %>円(税抜)</p>
                 </div>
                 <% end %>
             </div>
-            <div> <!-- ページング機能　-->
+            <div class="d-flex justify-content-center"> <!-- ページング機能　-->
                 <%= paginate @items %>
             </div>
         </div>

--- a/app/views/customer/items/show.html.erb
+++ b/app/views/customer/items/show.html.erb
@@ -10,7 +10,7 @@
     <div class="col-md-6">
       <h2><%= @item.name %></h2>
       <p><%= @item.introduction %></p>
-      <h2>￥<%= @item.price %>円</h2>
+      <h2>￥<%= tax_price(@item.price).to_s(:delimited) %>円(</h2>
       <%= form_with model: @cart_item, url: customer_cart_items_path, local:true do |f| %>
        <%= f.select :count, [["1", "1"], ["2", "2"], ["3", "3"], ["4", "4"], ["5", "5"]], include_blank: "個数選択　　　" %>
        <%= f.hidden_field :item_id, :value => @item.id %>

--- a/app/views/customer/items/show.html.erb
+++ b/app/views/customer/items/show.html.erb
@@ -8,14 +8,18 @@
       <%= attachment_image_tag @item, :image, fallback: "no-image.jpg", size: "250x200" %>
     </div>
     <div class="col-md-6">
-      <h2><%= @item.name %></h2>
+      <h3><%= @item.name %></h3>
       <p><%= @item.introduction %></p>
-      <h2>￥<%= tax_price(@item.price).to_s(:delimited) %>円(</h2>
+      <h4>￥<%= tax_price(@item.price).to_s(:delimited) %>円(税込)</h4>
       <%= form_with model: @cart_item, url: customer_cart_items_path, local:true do |f| %>
-       <%= f.select :count, [["1", "1"], ["2", "2"], ["3", "3"], ["4", "4"], ["5", "5"]], include_blank: "個数選択　　　" %>
+      <div class="row mt-5">
+       <%= f.select :count, options_for_select((1..10).to_a), include_blank: "個数選択" %>
        <%= f.hidden_field :item_id, :value => @item.id %>
+       <div class="col-md-4 ml-5">
        <%= f.submit "カートに入れる", class: "btn btn-success" %>
+       </div>
       <% end %>
+      </div>
     </div>
    </div>
   </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "First" page
-  - available local variables
-    url:           url to the first page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,8 +1,3 @@
-<%# Non-link tag that stands for skipped pages...
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Last" page
-  - available local variables
-    url:           url to the last page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Next" page
-  - available local variables
-    url:           url to the next page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,12 +1,9 @@
-<%# Link showing page number
-  - available local variables
-    page:          a page object for "this" page
-    url:           url to this page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
-</span>
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,25 +1,17 @@
-<%# The container tag
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
-    paginator:     the paginator that renders the pagination tags inside
--%>
-<%= paginator.render do -%>
-  <nav class="pagination" role="navigation" aria-label="pager">
-    <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
-    <% each_page do |page| -%>
-      <% if page.display_tag? -%>
-        <%= page_tag page %>
-      <% elsif !page.was_truncated? -%>
-        <%= gap_tag %>
-      <% end -%>
-    <% end -%>
-    <% unless current_page.out_of_range? %>
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
       <%= next_page_tag unless current_page.last? %>
       <%= last_page_tag unless current_page.last? %>
-    <% end %>
+    </ul>
   </nav>
-<% end -%>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Previous" page
-  - available local variables
-    url:           url to the previous page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>


### PR DESCRIPTION
レイアウト調整　
商品一覧を１列４個に 
ｋａｍｉｎａｒｉのページングのレイアウト変更
商品詳細　カートに入れるボタン等の位置調整
商品詳細に関してはまだ直せる部分あるかも？

細かな調整　(税込)等表示　個数選択の記述を見やすいように変更
